### PR TITLE
typo

### DIFF
--- a/examples/client-only/Makefile
+++ b/examples/client-only/Makefile
@@ -1,5 +1,5 @@
 BIN = ../../node_modules/.bin
-PATH := $(BIN)/$(PATH)
+PATH := $(BIN):$(PATH)
 
 build: bundle.js
 

--- a/examples/server-rendering/Makefile
+++ b/examples/server-rendering/Makefile
@@ -1,5 +1,5 @@
 BIN = ../../node_modules/.bin
-PATH := $(BIN)/$(PATH)
+PATH := $(BIN):$(PATH)
 
 start: build
 	@node server.js


### PR DESCRIPTION
causing ../../node_modules/.bin not being properly set in PATH
causing browserify not being in PATH...
causing make to crash :0
