### PR TITLE
fix duplicate link elements in DOM

### DIFF
--- a/lib/StylesheetImage.js
+++ b/lib/StylesheetImage.js
@@ -11,7 +11,7 @@ if (ExecutionEnvironment.canUseDOM) {
 function populateActiveImages() {
   var images = document.head.querySelectorAll('link[data-react-stylesheet]');
   for (var i = 0, len = images.length; i < len; i++) {
-    activeImages[images[i].href] = true;
+    activeImages[images[i].getAttribute('href')] = true;
   }
 }
 


### PR DESCRIPTION
the html [spec](http://www.w3.org/TR/REC-html40/struct/links.html#adef-href) says the href _property_ of a link element should always be a full link and this i how it's implemented in browsers [except IE of course...](http://stackoverflow.com/a/10280487).

so for example if you create a link element like so:

``` html
<link href="styles/main.css">
```

once it's mounted in the dom, its href _property_ ie HTMLLinkElement.href is set to `protocol:/host:port/styles/main.css` so say `http://localhost:3000/styles/main.css` for the above link element. whereas it's href _attribute_ ie HTMLLinkElement.getAttribute('href') is set to `styles/main.css`.

in the [code](https://github.com/andreypopp/react-stylesheet/blob/659cb43172998b9f806bb5373832426abdf7bf55/lib/StylesheetImage.js#L14), during initialization, the activeImages set is filled using the href _property_ of the existing link elements (so full links) but when mounting new components, the check that's done for whether to inject their stylesheets uses the values passed in the components' `stylesheets` array which can be simple paths/uris like:

``` js
React.createClass({
  mixins: [ReactStylesheet],
  stylesheets: [ 'styles/main.css' ]
});
```

so in that case if this stylesheets' link is already in the dom when this component mounts, the check fails `'http://localhost:3000/styles/main.css' !== 'styles/main.css'` so a duplicate link element gets injected : /

this actually happens in the current [server-rendering example](https://github.com/andreypopp/react-stylesheet/tree/659cb43172998b9f806bb5373832426abdf7bf55/examples/server-rendering)

i fixed this by simply using the link hrefs _attribute_ rather than its _property_ for the activeImages set
